### PR TITLE
Remove optional chaining bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,29 +98,39 @@ On the left-navbar, `MeiliSearch` appears under the `PLUGINS` category. If it do
 
 First, you need to configure credentials via the strapi config, or on the plugin page.
 
-To use the strapi config add the following to `config/plugins.js` or `config/[NODE_ENV]/plugin.js`:
-```js
-module.exports = () => ({
-  //...
-  "meilisearch": {
-    // Your meili host
-    "host": "http://localhost:7700"
-    // Your master key
-    "api_key": "masterKey",
-  }
-  //...
-})
-```
+#### Using the plugin page
 
-Otherwise, add your MeiliSearch credentials in the upper box of the MeiliSearch plugin page.
+You can add you MeiliSearch credentials in the upper box of the MeiliSearch plugin page.
 
-For example, using the credentials from the section above: `Run MeiliSearch`, it looks like this:
+For example, using the credentials from the section above: [`Run MeiliSearch`](#-run-meilisearch), the following screen shows where the information should be.
 
 <p align="center">
 <img src="./assets/credentials.png" alt="Add your credentials" width="600"/>
 </p>
 
 Once completed, click on the `add` button.
+
+#### Using a config file
+
+To use the strapi config add the following to `config/plugins.js` or `config/[NODE_ENV]/plugin.js`:
+
+```js
+module.exports = () => ({
+  //...
+  meilisearch: {
+    // Your meili host
+    host: "http://localhost:7700"
+    // Your master key
+    api_key: "masterKey",
+  }
+  //...
+})
+```
+
+Using `config/[NODE_ENV]/plugin.js`, it is possible to have a config file for different environments.
+
+Note that if you use both method, the config file overwrites the credentials added through the plugin page.
+
 
 ### 🚛 Add your collections to MeiliSearch <!-- omit in toc -->
 

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -106,8 +106,14 @@ async function initHooks(store) {
 }
 
 async function updateStoreCredentials({ store }) {
-  const apiKey = strapi.config.plugins?.meilisearch?.apiKey
-  const host = strapi.config.plugins?.meilisearch?.host
+  // optional chaining is not natively supported by node 12.
+  let apiKey = false
+  let host = false
+  const { plugins } = strapi.config
+  if (plugins && plugins.meilisearch) {
+    apiKey = plugins.meilisearch.apiKey
+    host = plugins.meilisearch.host
+  }
 
   if (apiKey) {
     await store.set({

--- a/playground/config/plugins.js
+++ b/playground/config/plugins.js
@@ -1,4 +1,0 @@
-module.exports = () => {
-
-  return {}
-}


### PR DESCRIPTION
Remove optionnal chaining that is not supported natively by node 12. As this plugin still supports node 12 it should by compatible.